### PR TITLE
feat: surfacing circular $refs in a new `circularRefs` property on the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ import $RefParser from "@readme/json-schema-ref-parser";
 
 * Forces YAML to conform to JSON-compatible types. https://github.com/APIDevTools/json-schema-ref-parser/pull/247
 * Improved support for OpenAPI 3.1 definitions where `$ref` pointers may live alongside a `description` property. https://github.com/readmeio/json-schema-ref-parser/pull/2
+* Exposes a new `$refs.circularRefs` property containing an array of any circular `$ref` pointers that may exist within the schema definition.
 
 ## Browser support
 JSON Schema $Ref Parser supports recent versions of every major web browser.  Older browsers may require [Babel](https://babeljs.io/) and/or [polyfills](https://babeljs.io/docs/en/next/babel-polyfill).

--- a/docs/refs.md
+++ b/docs/refs.md
@@ -8,6 +8,7 @@ This object is a map of JSON References and their resolved values.  It also has 
 
 ##### Properties
 - [`circular`](#circular)
+- [`circularRefs`](#circularRefs)
 
 ##### Methods
 - [`paths()`](#pathstypes)
@@ -29,6 +30,22 @@ await parser.dereference("my-schema.json");
 
 if (parser.$refs.circular) {
   console.log('The schema contains circular references');
+}
+```
+
+
+### `circularRefs`
+
+- **Type:** `array`
+
+This property contains an array of any [circular references](README.md#circular-refs) that may the schema contains.
+
+```javascript
+let parser = new $RefParser();
+await parser.dereference("my-schema.json");
+
+if (parser.$refs.circular) {
+  console.log(parser.$refs.circularRefs);
 }
 ```
 

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -254,8 +254,11 @@ function dereference$Ref($ref, path, pathFromRoot, parents, processedObjects, de
  */
 function foundCircularReference(keyPath, $refs, options) {
   $refs.circular = true;
+  $refs.circularRefs.push(keyPath);
+
   if (!options.dereference.circular) {
     throw ono.reference(`Circular $ref pointer found at ${keyPath}`);
   }
+
   return true;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -362,6 +362,11 @@ declare namespace $RefParser {
     public circular: boolean;
 
     /**
+     * This property contains any circular references that may be within the schema.
+     */
+    public circularRefs: string[];
+
+    /**
      * Returns the paths/URLs of all the files in your schema (including the main schema file).
      *
      * See https://apitools.dev/json-schema-ref-parser/docs/refs.html#pathstypes

--- a/lib/refs.js
+++ b/lib/refs.js
@@ -17,6 +17,13 @@ function $Refs() {
   this.circular = false;
 
   /**
+   * Contains any circular references that may be present within the schema.
+   *
+   * @type {array}
+   */
+  this.circularRefs = [];
+
+  /**
    * A map of paths/urls to {@link $Ref} objects
    *
    * @type {object}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,16 @@
       "devDependencies": {
         "@jsdevtools/host-environment": "^2.1.2",
         "@jsdevtools/karma-config": "^3.1.7",
-        "@readme/eslint-config": "^10.1.0",
-        "@types/node": "^18.0.0",
+        "@readme/eslint-config": "^10.3.1",
+        "@types/node": "^18.11.11",
         "chai": "^4.3.6",
         "chai-subset": "^1.6.0",
-        "eslint": "^8.11.0",
+        "eslint": "^8.29.0",
         "karma": "^6.3.17",
         "karma-cli": "^2.0.0",
         "mocha": "^10.0.0",
         "nyc": "^15.0.1",
-        "prettier": "^2.6.0",
+        "prettier": "^2.8.1",
         "typescript": "^4.6.2"
       }
     },
@@ -1687,6 +1687,21 @@
         "node": "^14 || ^16 || ^17 || ^18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz",
+      "integrity": "sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -2113,9 +2128,9 @@
       "dev": true
     },
     "node_modules/@readme/eslint-config": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.2.0.tgz",
-      "integrity": "sha512-QNttw5J3ejDd2obA7u2K8AbydbPPpDBoRA0iJk7kpuMYQ6N+phkkJbXTI6aYkp9bIL9AnZ6wKg+IrOUlb+EhWg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.3.1.tgz",
+      "integrity": "sha512-x2UCpBqSBQX6TV49nCq76qhuanugV0y34k5Gj0lTRo1bkJdVGAa7N/58qiPsImxnRemX7WJclQ9St1/N067J4Q==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -2138,7 +2153,7 @@
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.5.1",
-        "eslint-plugin-unicorn": "^44.0.0",
+        "eslint-plugin-unicorn": "^45.0.1",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       },
       "engines": {
@@ -2340,9 +2355,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
+      "version": "18.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
+      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -4602,10 +4617,13 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+      "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
@@ -6222,9 +6240,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
@@ -6961,24 +6979,26 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "44.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
-      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+      "version": "45.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.1.tgz",
+      "integrity": "sha512-tLnIw5oDJJc3ILYtlKtqOxPP64FZLTkZkgeuoN6e7x6zw+rhBjOxyvq2c7577LGxXuIhBYrwisZuKNqOOHp3BA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.19.1",
-        "ci-info": "^3.4.0",
+        "@eslint-community/eslint-utils": "^4.1.0",
+        "ci-info": "^3.6.1",
         "clean-regexp": "^1.0.0",
-        "eslint-utils": "^3.0.0",
         "esquery": "^1.4.0",
         "indent-string": "^4.0.0",
         "is-builtin-module": "^3.2.0",
+        "jsesc": "^3.0.2",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.24",
+        "regjsparser": "^0.9.1",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
         "strip-indent": "^3.0.0"
       },
       "engines": {
@@ -6988,7 +7008,40 @@
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.1"
+        "eslint": ">=8.28.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "dev": true,
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/safe-regex": {
@@ -12378,9 +12431,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -13479,9 +13532,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -17117,6 +17170,15 @@
         "jsdoc-type-pratt-parser": "~3.0.1"
       }
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz",
+      "integrity": "sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -17451,9 +17513,9 @@
       "dev": true
     },
     "@readme/eslint-config": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.2.0.tgz",
-      "integrity": "sha512-QNttw5J3ejDd2obA7u2K8AbydbPPpDBoRA0iJk7kpuMYQ6N+phkkJbXTI6aYkp9bIL9AnZ6wKg+IrOUlb+EhWg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.3.1.tgz",
+      "integrity": "sha512-x2UCpBqSBQX6TV49nCq76qhuanugV0y34k5Gj0lTRo1bkJdVGAa7N/58qiPsImxnRemX7WJclQ9St1/N067J4Q==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -17476,7 +17538,7 @@
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.5.1",
-        "eslint-plugin-unicorn": "^44.0.0",
+        "eslint-plugin-unicorn": "^45.0.1",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
@@ -17637,9 +17699,9 @@
       }
     },
     "@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
+      "version": "18.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
+      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -19452,9 +19514,9 @@
       }
     },
     "ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+      "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
       "dev": true
     },
     "cipher-base": {
@@ -20806,9 +20868,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
@@ -21512,27 +21574,52 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "44.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
-      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+      "version": "45.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.1.tgz",
+      "integrity": "sha512-tLnIw5oDJJc3ILYtlKtqOxPP64FZLTkZkgeuoN6e7x6zw+rhBjOxyvq2c7577LGxXuIhBYrwisZuKNqOOHp3BA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.19.1",
-        "ci-info": "^3.4.0",
+        "@eslint-community/eslint-utils": "^4.1.0",
+        "ci-info": "^3.6.1",
         "clean-regexp": "^1.0.0",
-        "eslint-utils": "^3.0.0",
         "esquery": "^1.4.0",
         "indent-string": "^4.0.0",
         "is-builtin-module": "^3.2.0",
+        "jsesc": "^3.0.2",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.24",
+        "regjsparser": "^0.9.1",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
         "strip-indent": "^3.0.0"
       },
       "dependencies": {
+        "jsesc": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+          "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+          "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+              "dev": true
+            }
+          }
+        },
         "safe-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
@@ -25559,9 +25646,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -26433,9 +26520,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -54,16 +54,16 @@
   "devDependencies": {
     "@jsdevtools/host-environment": "^2.1.2",
     "@jsdevtools/karma-config": "^3.1.7",
-    "@readme/eslint-config": "^10.1.0",
-    "@types/node": "^18.0.0",
+    "@readme/eslint-config": "^10.3.1",
+    "@types/node": "^18.11.11",
     "chai": "^4.3.6",
     "chai-subset": "^1.6.0",
-    "eslint": "^8.11.0",
+    "eslint": "^8.29.0",
     "karma": "^6.3.17",
     "karma-cli": "^2.0.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.1",
-    "prettier": "^2.6.0",
+    "prettier": "^2.8.1",
     "typescript": "^4.6.2"
   },
   "dependencies": {

--- a/test/specs/__({[ % & $ # @ ` ~ ,)}]__/special-characters.spec.js
+++ b/test/specs/__({[ % & $ # @ ` ~ ,)}]__/special-characters.spec.js
@@ -36,8 +36,10 @@ describe('File names with special characters', function () {
     );
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/absolute-root/absolute-root.spec.js
+++ b/test/specs/absolute-root/absolute-root.spec.js
@@ -99,6 +99,7 @@ describe('When executed in the context of root directory', function () {
     const schema = await parser.dereference(path.abs('specs/absolute-root/absolute-root.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.name).to.equal(schema.definitions.name);
     expect(schema.definitions['required string'])
@@ -106,8 +107,10 @@ describe('When executed in the context of root directory', function () {
       .to.equal(schema.definitions.name.properties.last)
       .to.equal(schema.properties.name.properties.first)
       .to.equal(schema.properties.name.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/circular-extended/circular-extended.spec.js
+++ b/test/specs/circular-extended/circular-extended.spec.js
@@ -16,9 +16,11 @@ describe('Schema with circular $refs that extend each other', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.self);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular-extended/circular-extended-self.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -37,8 +39,11 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.dereference(path.rel('specs/circular-extended/circular-extended-self.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.self);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
     });
 
     it('should not dereference circular $refs if "options.$refs.circular" is "ignore"', async function () {
@@ -48,8 +53,11 @@ describe('Schema with circular $refs that extend each other', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.self);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
     });
 
     it('should throw an error if "options.$refs.circular" is false', async function () {
@@ -68,6 +76,8 @@ describe('Schema with circular $refs that extend each other', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
       }
     });
 
@@ -76,9 +86,11 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.bundle(path.rel('specs/circular-extended/circular-extended-self.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(bundledSchema.self);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 
@@ -89,9 +101,11 @@ describe('Schema with circular $refs that extend each other', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.ancestor);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular-extended/circular-extended-ancestor.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -114,8 +128,12 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.dereference(path.rel('specs/circular-extended/circular-extended-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.ancestor.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/properties/spouse');
+
       // Reference equality
       expect(schema.definitions.person.properties.spouse.properties).to.equal(schema.definitions.person.properties);
       expect(schema.definitions.person.properties.pet.properties).to.equal(schema.definitions.pet.properties);
@@ -128,8 +146,11 @@ describe('Schema with circular $refs that extend each other', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.ancestor.ignoreCircular$Refs);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/properties/spouse');
     });
 
     it('should throw an error if "options.$refs.circular" is false', async function () {
@@ -150,6 +171,8 @@ describe('Schema with circular $refs that extend each other', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/properties/spouse');
       }
     });
 
@@ -158,9 +181,11 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.bundle(path.rel('specs/circular-extended/circular-extended-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(bundledSchema.ancestor);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 
@@ -171,9 +196,11 @@ describe('Schema with circular $refs that extend each other', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.indirect);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular-extended/circular-extended-indirect.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -198,8 +225,12 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.dereference(path.rel('specs/circular-extended/circular-extended-indirect.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirect.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/properties/parents/items');
+
       // Reference equality
       expect(schema.definitions.parent.properties.children.items.properties).to.equal(
         schema.definitions.child.properties
@@ -217,8 +248,11 @@ describe('Schema with circular $refs that extend each other', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirect.ignoreCircular$Refs);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/properties/parents/items');
     });
 
     it('should throw an error if "options.$refs.circular" is false', async function () {
@@ -239,6 +273,8 @@ describe('Schema with circular $refs that extend each other', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/properties/parents/items');
       }
     });
 
@@ -247,9 +283,11 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.bundle(path.rel('specs/circular-extended/circular-extended-indirect.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(bundledSchema.indirect);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 
@@ -262,9 +300,11 @@ describe('Schema with circular $refs that extend each other', function () {
       expect(parser.$refs.paths()).to.deep.equal([
         path.abs('specs/circular-extended/circular-extended-indirect-ancestor.yaml'),
       ]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -291,8 +331,12 @@ describe('Schema with circular $refs that extend each other', function () {
       );
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirectAncestor.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/properties');
+
       // Reference equality
       expect(schema.definitions.parent.properties.child.properties).to.equal(schema.definitions.child.properties);
       expect(schema.definitions.child.properties.children.items.properties).to.equal(
@@ -309,8 +353,12 @@ describe('Schema with circular $refs that extend each other', function () {
       );
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirectAncestor.ignoreCircular$Refs);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(2);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/properties');
+      expect(parser.$refs.circularRefs[1]).to.contain('#/properties/children/items');
     });
 
     it('should throw an error if "options.$refs.circular" is false', async function () {
@@ -329,6 +377,8 @@ describe('Schema with circular $refs that extend each other', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/properties');
       }
     });
 
@@ -337,9 +387,11 @@ describe('Schema with circular $refs that extend each other', function () {
       const schema = await parser.bundle(path.rel('specs/circular-extended/circular-extended-indirect-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(bundledSchema.indirectAncestor);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 });

--- a/test/specs/circular-external-direct/circular-external-direct.spec.js
+++ b/test/specs/circular-external-direct/circular-external-direct.spec.js
@@ -15,9 +15,11 @@ describe('Schema with direct circular (recursive) external $refs', function () {
     expect(parser.$refs.paths()).to.deep.equal([
       path.abs('specs/circular-external-direct/circular-external-direct-root.yaml'),
     ]);
+
     // The "circular" flag should NOT be set
     // (it only gets set by `dereference`)
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should dereference successfully', async function () {
@@ -27,7 +29,10 @@ describe('Schema with direct circular (recursive) external $refs', function () {
     );
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // The "circular" flag should be set
     expect(parser.$refs.circular).to.equal(true);
+    expect(parser.$refs.circularRefs).to.have.length(1);
+    expect(parser.$refs.circularRefs[0]).to.contain('#/foo/foo');
   });
 });

--- a/test/specs/circular-external/circular-external.spec.js
+++ b/test/specs/circular-external/circular-external.spec.js
@@ -15,9 +15,11 @@ describe('Schema with circular (recursive) external $refs', function () {
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(parsedSchema.schema);
     expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular-external/circular-external.yaml')]);
+
     // The "circular" flag should NOT be set
     // (it only gets set by `dereference`)
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it(
@@ -42,8 +44,14 @@ describe('Schema with circular (recursive) external $refs', function () {
     const schema = await parser.dereference(path.rel('specs/circular-external/circular-external.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // The "circular" flag should be set
     expect(parser.$refs.circular).to.equal(true);
+    expect(parser.$refs.circularRefs).to.have.length(3);
+    expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
+    expect(parser.$refs.circularRefs[1]).to.contain('#/properties/spouse');
+    expect(parser.$refs.circularRefs[2]).to.contain('#/properties/parents/items');
+
     // Reference equality
     expect(schema.definitions.person.properties.spouse).to.equal(schema.definitions.person);
     expect(schema.definitions.parent.properties.children.items).to.equal(schema.definitions.child);
@@ -66,6 +74,8 @@ describe('Schema with circular (recursive) external $refs', function () {
 
       // $Refs.circular should be true
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
     }
   });
 
@@ -74,8 +84,10 @@ describe('Schema with circular (recursive) external $refs', function () {
     const schema = await parser.bundle(path.rel('specs/circular-external/circular-external.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(bundledSchema);
+
     // The "circular" flag should NOT be set
     // (it only gets set by `dereference`)
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 });

--- a/test/specs/circular/circular.spec.js
+++ b/test/specs/circular/circular.spec.js
@@ -15,9 +15,11 @@ describe('Schema with circular (recursive) $refs', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.self);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular/circular-self.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -34,8 +36,12 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(path.rel('specs/circular/circular-self.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.self);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
+
       // Reference equality
       expect(schema.definitions.child.properties.pet).to.equal(schema.definitions.pet);
     });
@@ -46,8 +52,12 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(firstPassSchema);
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.self);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
+
       // Reference equality
       expect(schema.definitions.child.properties.pet).to.equal(schema.definitions.pet);
     });
@@ -59,8 +69,11 @@ describe('Schema with circular (recursive) $refs', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.self);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
     });
 
     it('should throw an error if "options.$refs.circular" is false', async function () {
@@ -77,6 +90,8 @@ describe('Schema with circular (recursive) $refs', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/thing');
       }
     });
 
@@ -85,9 +100,11 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.bundle(path.rel('specs/circular/circular-self.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.self);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 
@@ -98,9 +115,11 @@ describe('Schema with circular (recursive) $refs', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.ancestor);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular/circular-ancestor.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -117,8 +136,12 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(path.rel('specs/circular/circular-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.ancestor.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/person/properties/spouse');
+
       // Reference equality
       expect(schema.definitions.person.properties.spouse).to.equal(schema.definitions.person);
       expect(schema.definitions.person.properties.pet).to.equal(schema.definitions.pet);
@@ -130,8 +153,12 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(firstPassSchema);
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.ancestor.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/person/properties/spouse');
+
       // Reference equality
       expect(schema.definitions.person.properties.spouse).to.equal(schema.definitions.person);
       expect(schema.definitions.person.properties.pet).to.equal(schema.definitions.pet);
@@ -144,8 +171,12 @@ describe('Schema with circular (recursive) $refs', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.ancestor.ignoreCircular$Refs);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/person/properties/spouse');
+
       // Reference equality
       expect(schema.definitions.person.properties.pet).to.equal(schema.definitions.pet);
     });
@@ -166,6 +197,8 @@ describe('Schema with circular (recursive) $refs', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/person/properties/spouse');
       }
     });
 
@@ -174,9 +207,11 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.bundle(path.rel('specs/circular/circular-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.ancestor);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 
@@ -187,9 +222,11 @@ describe('Schema with circular (recursive) $refs', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.indirect);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular/circular-indirect.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -206,8 +243,12 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(path.rel('specs/circular/circular-indirect.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirect.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/child/properties/parents/items');
+
       // Reference equality
       expect(schema.definitions.parent.properties.children.items).to.equal(schema.definitions.child);
       expect(schema.definitions.child.properties.parents.items).to.equal(schema.definitions.parent);
@@ -219,8 +260,14 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(firstPassSchema);
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirect.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain(
+        '#/definitions/parent/properties/children/items/properties/parents/items'
+      );
+
       // Reference equality
       expect(schema.definitions.parent.properties.children.items).to.equal(schema.definitions.child);
       expect(schema.definitions.child.properties.parents.items).to.equal(schema.definitions.parent);
@@ -233,8 +280,12 @@ describe('Schema with circular (recursive) $refs', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirect.ignoreCircular$Refs);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/child/properties/parents/items');
+
       // Reference equality
       expect(schema.definitions.child.properties.pet).to.equal(schema.definitions.pet);
     });
@@ -257,6 +308,8 @@ describe('Schema with circular (recursive) $refs', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/child/properties/parents/items');
       }
     });
 
@@ -265,9 +318,11 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.bundle(path.rel('specs/circular/circular-indirect.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.indirect);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 
@@ -278,9 +333,11 @@ describe('Schema with circular (recursive) $refs', function () {
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.indirectAncestor);
       expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/circular/circular-indirect-ancestor.yaml')]);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
 
     it(
@@ -297,8 +354,12 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(path.rel('specs/circular/circular-indirect-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirectAncestor.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/child/properties/children/items');
+
       // Reference equality
       expect(schema.definitions.parent.properties.child).to.equal(schema.definitions.child);
       expect(schema.definitions.child.properties.children.items).to.equal(schema.definitions.child);
@@ -310,8 +371,14 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.dereference(firstPassSchema);
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirectAncestor.fullyDereferenced);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain(
+        '#/definitions/parent/properties/child/properties/children/items'
+      );
+
       // Reference equality
       expect(schema.definitions.parent.properties.child).to.equal(schema.definitions.child);
       expect(schema.definitions.child.properties.children.items).to.equal(schema.definitions.child);
@@ -324,8 +391,12 @@ describe('Schema with circular (recursive) $refs', function () {
       });
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(dereferencedSchema.indirectAncestor.ignoreCircular$Refs);
+
       // The "circular" flag should be set
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/child/properties/children/items');
+
       // Reference equality
       expect(schema.definitions.child.properties.pet).to.equal(schema.definitions.pet);
     });
@@ -346,6 +417,8 @@ describe('Schema with circular (recursive) $refs', function () {
 
         // $Refs.circular should be true
         expect(parser.$refs.circular).to.equal(true);
+        expect(parser.$refs.circularRefs).to.have.length(1);
+        expect(parser.$refs.circularRefs[0]).to.contain('#/definitions/child/properties/children/items');
       }
     });
 
@@ -354,9 +427,11 @@ describe('Schema with circular (recursive) $refs', function () {
       const schema = await parser.bundle(path.rel('specs/circular/circular-indirect-ancestor.yaml'));
       expect(schema).to.equal(parser.schema);
       expect(schema).to.deep.equal(parsedSchema.indirectAncestor);
+
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+      expect(parser.$refs.circularRefs).to.have.length(0);
     });
   });
 });

--- a/test/specs/deep-circular/deep-circular.spec.js
+++ b/test/specs/deep-circular/deep-circular.spec.js
@@ -15,9 +15,11 @@ describe('Schema with deeply-nested circular $refs', function () {
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(parsedSchema.schema);
     expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/deep-circular/deep-circular.yaml')]);
+
     // The "circular" flag should NOT be set
     // (it only gets set by `dereference`)
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it(
@@ -38,8 +40,14 @@ describe('Schema with deeply-nested circular $refs', function () {
     const schema = await parser.dereference(path.rel('specs/deep-circular/deep-circular.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // The "circular" flag should be set
     expect(parser.$refs.circular).to.equal(true);
+    expect(parser.$refs.circularRefs).to.have.length(1);
+    expect(parser.$refs.circularRefs[0]).to.contain(
+      '#/properties/level1/properties/level2/properties/level3/properties/level4/properties/level5/properties/level6/properties/level7/properties/level8/properties/level9/properties/level10/properties/level11/properties/level12/properties/level13/properties/level14/properties/level15/properties/level16/properties/level17/properties/level18/properties/level19/properties/level20/properties/level21/properties/level22/properties/level23/properties/level24/properties/level25/properties/level26/properties/level27/properties/level28/properties/level29/properties/level30'
+    );
+
     // Reference equality
     expect(schema.definitions.name)
       .to.equal(schema.properties.name)
@@ -73,6 +81,10 @@ describe('Schema with deeply-nested circular $refs', function () {
 
       // $Refs.circular should be true
       expect(parser.$refs.circular).to.equal(true);
+      expect(parser.$refs.circularRefs).to.have.length(1);
+      expect(parser.$refs.circularRefs[0]).to.contain(
+        '#/properties/level1/properties/level2/properties/level3/properties/level4/properties/level5/properties/level6/properties/level7/properties/level8/properties/level9/properties/level10/properties/level11/properties/level12/properties/level13/properties/level14/properties/level15/properties/level16/properties/level17/properties/level18/properties/level19/properties/level20/properties/level21/properties/level22/properties/level23/properties/level24/properties/level25/properties/level26/properties/level27/properties/level28/properties/level29/properties/level30'
+      );
     }
   });
 
@@ -81,8 +93,10 @@ describe('Schema with deeply-nested circular $refs', function () {
     const schema = await parser.bundle(path.rel('specs/deep-circular/deep-circular.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(bundledSchema);
+
     // The "circular" flag should NOT be set
     // (it only gets set by `dereference`)
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 });

--- a/test/specs/deep/deep.spec.js
+++ b/test/specs/deep/deep.spec.js
@@ -35,6 +35,7 @@ describe('Schema with deeply-nested $refs', function () {
     const schema = await parser.dereference(path.rel('specs/deep/deep.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.name.type)
       .to.equal(schema.properties['level 1'].properties.name.type)
@@ -44,8 +45,10 @@ describe('Schema with deeply-nested $refs', function () {
         schema.properties['level 1'].properties['level 2'].properties['level 3'].properties['level 4'].properties.name
           .type
       );
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/empty/empty.spec.js
+++ b/test/specs/empty/empty.spec.js
@@ -26,8 +26,10 @@ describe('Empty schema', function () {
     expect(schema).to.be.empty;
     expect(parser.schema).to.equal(schema);
     expect(parser.$refs.paths()).to.deep.equal([path.abs('specs/empty/empty.json')]);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/external-from-internal/external-from-internal.spec.js
+++ b/test/specs/external-from-internal/external-from-internal.spec.js
@@ -75,6 +75,7 @@ describe('Schema with two external refs to the same value and internal ref befor
     const schema = await parser.dereference(path.rel('specs/external-from-internal/external-from-internal.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.internal1).to.equal(schema.internal2);
     expect(schema.internal2).to.equal(schema.external1);
@@ -86,8 +87,10 @@ describe('Schema with two external refs to the same value and internal ref befor
       .to.equal(schema.internal4.test)
       .to.equal(schema.external1.test)
       .to.equal(schema.external2.test);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/external-multiple/external-multiple.spec.js
+++ b/test/specs/external-multiple/external-multiple.spec.js
@@ -33,10 +33,13 @@ describe('Schema with multiple external $refs to different parts of a file', fun
     const schema = await parser.dereference(path.rel('specs/external-multiple/external-multiple.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.user.example).to.equal(schema.example.user);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/external-partial/external-partial.spec.js
+++ b/test/specs/external-partial/external-partial.spec.js
@@ -37,10 +37,13 @@ describe('Schema with $refs to parts of external files', function () {
     const schema = await parser.dereference(path.rel('specs/external-partial/external-partial.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.name.properties.first).to.equal(schema.properties.name.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/external/external.spec.js
+++ b/test/specs/external/external.spec.js
@@ -83,6 +83,7 @@ describe('Schema with external $refs', function () {
     const schema = await parser.dereference(path.rel('specs/external/external.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.name).to.equal(schema.definitions.name);
     expect(schema.definitions['required string'])
@@ -90,8 +91,10 @@ describe('Schema with external $refs', function () {
       .to.equal(schema.definitions.name.properties.last)
       .to.equal(schema.properties.name.properties.first)
       .to.equal(schema.properties.name.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/internal/internal.spec.js
+++ b/test/specs/internal/internal.spec.js
@@ -27,6 +27,7 @@ describe('Schema with internal $refs', function () {
     const schema = await parser.dereference(path.rel('specs/internal/internal.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.name).to.equal(schema.definitions.name);
     expect(schema.definitions.requiredString)
@@ -34,8 +35,10 @@ describe('Schema with internal $refs', function () {
       .to.equal(schema.definitions.name.properties.last)
       .to.equal(schema.properties.name.properties.first)
       .to.equal(schema.properties.name.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/invalid/invalid.spec.js
+++ b/test/specs/invalid/invalid.spec.js
@@ -155,6 +155,7 @@ describe('Invalid syntax', function () {
               name: ParserError.name,
               message: message =>
                 message.includes('invalid.json: Unexpected end of JSON input') ||
+                message.includes("Expected property name or '}'") ||
                 message.includes('invalid.json: JSON.parse: end of data while reading object contents') || // Firefox
                 message.includes("invalid.json: JSON Parse error: Expected '}'") || // Safari
                 message.includes('invalid.json: JSON.parse Error: Invalid character') || // Edge
@@ -318,6 +319,7 @@ describe('Invalid syntax', function () {
               name: ParserError.name,
               message: message =>
                 message.includes('invalid.json: Unexpected end of JSON input') ||
+                message.includes("Expected property name or '}'") ||
                 message.includes('invalid.json: JSON.parse: end of data while reading object contents') || // Firefox
                 message.includes("invalid.json: JSON Parse error: Expected '}'") || // Safari
                 message.includes('invalid.json: JSON.parse Error: Invalid character') || // Edge

--- a/test/specs/no-refs/no-refs.spec.js
+++ b/test/specs/no-refs/no-refs.spec.js
@@ -25,8 +25,10 @@ describe('Schema without any $refs', function () {
     const schema = await parser.dereference(path.rel('specs/no-refs/no-refs.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(parsedSchema);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/oas31/oas31.spec.js
+++ b/test/specs/oas31/oas31.spec.js
@@ -26,8 +26,10 @@ describe('Schema with OpenAPI 3.1 $ref description/schema overrides', function (
     const schema = await parser.dereference(path.rel('specs/oas31/oas31.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/object-source-with-path/object-source-with-path.spec.js
+++ b/test/specs/object-source-with-path/object-source-with-path.spec.js
@@ -58,6 +58,7 @@ describe('Object sources with file paths', function () {
     ];
     expect(parser.$refs.paths()).to.have.same.members(expectedPaths);
     expect(parser.$refs.values()).to.have.keys(expectedPaths);
+
     // Reference equality
     expect(schema.properties.name).to.equal(schema.definitions.name);
     expect(schema.definitions.requiredString)
@@ -65,8 +66,10 @@ describe('Object sources with file paths', function () {
       .to.equal(schema.definitions.name.properties.last)
       .to.equal(schema.properties.name.properties.first)
       .to.equal(schema.properties.name.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle an object that references external files', async function () {

--- a/test/specs/object-source/object-source.spec.js
+++ b/test/specs/object-source/object-source.spec.js
@@ -43,6 +43,7 @@ describe('Object sources (instead of file paths)', function () {
     ];
     expect(parser.$refs.paths()).to.have.same.members(expectedPaths);
     expect(parser.$refs.values()).to.have.keys(expectedPaths);
+
     // Reference equality
     expect(schema.properties.name).to.equal(schema.definitions.name);
     expect(schema.definitions.requiredString)
@@ -50,8 +51,10 @@ describe('Object sources (instead of file paths)', function () {
       .to.equal(schema.definitions.name.properties.last)
       .to.equal(schema.properties.name.properties.first)
       .to.equal(schema.properties.name.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle an object that references external files', async function () {

--- a/test/specs/parsers/parsers.spec.js
+++ b/test/specs/parsers/parsers.spec.js
@@ -45,8 +45,10 @@ describe('References to non-JSON files', function () {
     expect(schema).to.equal(parser.schema);
     schema.definitions.binary = helper.convertNodeBuffersToPOJOs(schema.definitions.binary);
     expect(schema).to.deep.equal(dereferencedSchema.defaultParsers);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/root/root.spec.js
+++ b/test/specs/root/root.spec.js
@@ -37,10 +37,13 @@ describe('Schema with a top-level (root) $ref', function () {
     const schema = await parser.dereference(path.rel('specs/root/root.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.first).to.equal(schema.properties.last);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/substrings/substrings.spec.js
+++ b/test/specs/substrings/substrings.spec.js
@@ -35,12 +35,15 @@ describe('$refs that are substrings of each other', function () {
     const schema = await parser.dereference(path.rel('specs/substrings/substrings.yaml'));
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
+
     // Reference equality
     expect(schema.properties.firstName).to.equal(schema.definitions.name);
     expect(schema.properties.middleName).to.equal(schema.definitions['name-with-min-length']);
     expect(schema.properties.lastName).to.equal(schema.definitions['name-with-min-length-max-length']);
+
     // The "circular" flag should NOT be set
     expect(parser.$refs.circular).to.equal(false);
+    expect(parser.$refs.circularRefs).to.have.length(0);
   });
 
   it('should bundle successfully', async function () {

--- a/test/specs/typescript-definition.spec.ts
+++ b/test/specs/typescript-definition.spec.ts
@@ -16,6 +16,7 @@ let parser = new $RefParser();
 
 // $RefParser instance properties
 assert(parser.$refs.circular === true);
+assert(Array.isArray(parser.$refs.circularRefs));
 assert(parser.schema.type === "object");
 
 


### PR DESCRIPTION
## 🧰 Changes

This exposes a new `circularRefs` property on the `parser.$refs` object that contains an array of any circular `$ref` pointers that exist within the schema definition.