### PR TITLE
fix: throw error for invalid $refs missing the `/` 

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,3 +14,5 @@ rules:
   no-use-before-define: off
   node/no-deprecated-api: off # `url.parse` has been deprecated but `url.URL` isn't a good replacement yet.
   prefer-rest-params: off
+parserOptions:
+  ecmaVersion: 2020

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -83,8 +83,9 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const keyPath = Pointer.join(path, key);
           const keyPathFromRoot = Pointer.join(pathFromRoot, key);
           const value = obj[key];
-
-          if (value?.$ref?.substring(0, 11) === '#components') {
+          const splitRef = value?.$ref?.split("/");
+          
+          if (splitRef?.length > 1 && splitRef?.includes("#components")) {
             throw new InvalidPointerError(value.$ref, keyPath);
           }
 

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -3,6 +3,7 @@ const { ono } = require('@jsdevtools/ono');
 
 const Pointer = require('./pointer');
 const $Ref = require('./ref');
+const { InvalidPointerError } = require('./util/errors');
 const url = require('./util/url');
 
 /**
@@ -82,6 +83,11 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const keyPath = Pointer.join(path, key);
           const keyPathFromRoot = Pointer.join(pathFromRoot, key);
           const value = obj[key];
+
+          if (value?.$ref?.substring(0, 11) === '#components') {
+            throw new InvalidPointerError(value.$ref, keyPath);
+          }
+
           let circular = false;
 
           if ($Ref.isAllowed$Ref(value, options)) {

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -84,7 +84,7 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const keyPathFromRoot = Pointer.join(pathFromRoot, key);
           const value = obj[key];
 
-          if (value?.$ref?.substring(0, 11) === '#components') {
+          if (value?.$ref?.substring(0, 2) !== '#/') {
             throw new InvalidPointerError(value.$ref, keyPath);
           }
 

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -84,14 +84,14 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const keyPathFromRoot = Pointer.join(pathFromRoot, key);
           const value = obj[key];
           // Ensure that there are valid refs. Refs like #components/schemas is invalid
-          const refSlashSplit = value?.$ref?.split("/");
-          
+          const refSlashSplit = value?.$ref?.split('/');
+
           // Catches external file refs: /absolute-root/absolute-root.yaml
-          const refHashSplit = value?.ref?.split("#");
+          const refHashSplit = value?.ref?.split('#');
 
           // Valid refs split on `/` should have an element with '#' as the last character
           // #components/schemas will not return a "validRef"
-          const validRef = refSlashSplit?.find(ele => ele.slice(-1) === "#")
+          const validRef = refSlashSplit?.find(ele => ele.slice(-1) === '#');
           if (refSlashSplit?.length > 1 && refHashSplit?.length > 1 && !validRef) {
             throw new InvalidPointerError(value.$ref, keyPath);
           }

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -84,7 +84,7 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const keyPathFromRoot = Pointer.join(pathFromRoot, key);
           const value = obj[key];
 
-          if (value?.$ref?.substring(0, 2) !== '#/') {
+          if (value?.$ref?.substring(0, 11) === '#components') {
             throw new InvalidPointerError(value.$ref, keyPath);
           }
 

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -83,9 +83,16 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const keyPath = Pointer.join(path, key);
           const keyPathFromRoot = Pointer.join(pathFromRoot, key);
           const value = obj[key];
-          const splitRef = value?.$ref?.split("/");
+          // Ensure that there are valid refs. Refs like #components/schemas is invalid
+          const refSlashSplit = value?.$ref?.split("/");
           
-          if (splitRef?.length > 1 && splitRef?.includes("#components")) {
+          // Catches external file refs: /absolute-root/absolute-root.yaml
+          const refHashSplit = value?.ref?.split("#");
+
+          // Valid refs split on `/` should have an element with '#' as the last character
+          // #components/schemas will not return a "validRef"
+          const validRef = refSlashSplit?.find(ele => ele.slice(-1) === "#")
+          if (refSlashSplit?.length > 1 && refHashSplit?.length > 1 && !validRef) {
             throw new InvalidPointerError(value.$ref, keyPath);
           }
 

--- a/test/specs/invalid-pointers/invalid-pointers.js
+++ b/test/specs/invalid-pointers/invalid-pointers.js
@@ -20,6 +20,16 @@ describe('Schema with invalid pointers', function () {
     }
   });
 
+  it('should throw an error for an invalid reference', async function () {
+    try {
+      await $RefParser.dereference(path.rel('specs/invalid-pointers/invalid-reference.json'));
+      helper.shouldNotGetCalled();
+    } catch (err) {
+      expect(err).to.be.an.instanceOf(InvalidPointerError);
+      expect(err.message).to.contain('Invalid $ref pointer "#components/". Pointers must begin with "#/"');
+    }
+  });
+
   it('should throw a grouped error for an invalid pointer if continueOnError is true', async function () {
     const parser = new $RefParser();
     try {

--- a/test/specs/invalid-pointers/invalid-reference.json
+++ b/test/specs/invalid-pointers/invalid-reference.json
@@ -1,0 +1,5 @@
+{
+  "foo": {
+    "$ref": "#components/"
+  }
+}


### PR DESCRIPTION
| 🚥 Resolves [RM-7648](https://linear.app/readme-io/issue/RM-7648/invalid-dollarref-passes-validation-crashes-hub) |
| :------------------- |

## 🧰 Changes
This fix seems a little... hard-coded? so I'm open to suggestions! It's literally just checking for the `#components` string anytime we try to dereference the file.

Additionally, I'm using some optional chaining but ESLint doesn't like it. Is it okay to update the `parserOptions.ecmaVersion` to `2020`?

## 🧬 QA & Testing
I don't have a great way to test this but I've written a test for that specific case and all the other tests are passing. 
