### PR TITLE
refactor: throw error for invalid $refs

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -87,12 +87,13 @@ function crawl(obj, path, pathFromRoot, parents, processedObjects, dereferencedC
           const refSlashSplit = value?.$ref?.split('/');
 
           // Catches external file refs: /absolute-root/absolute-root.yaml
-          const refHashSplit = value?.ref?.split('#');
+          const refHashSplit = value?.$ref?.split('#');
 
           // Valid refs split on `/` should have an element with '#' as the last character
           // #components/schemas will not return a "validRef"
           const validRef = refSlashSplit?.find(ele => ele.slice(-1) === '#');
-          if (refSlashSplit?.length > 1 && refHashSplit?.length > 1 && !validRef) {
+
+          if (refSlashSplit?.length > 1 && refHashSplit?.length > 1 && !validRef && !options.continueOnError) {
             throw new InvalidPointerError(value.$ref, keyPath);
           }
 

--- a/test/specs/invalid-pointers/invalid-pointers.spec.js
+++ b/test/specs/invalid-pointers/invalid-pointers.spec.js
@@ -10,13 +10,13 @@ const { expect } = chai;
 chai.use(chaiSubset);
 
 describe('Schema with invalid pointers', function () {
-  it('should throw an error for an invalid pointer', async function () {
+  it.only('should throw an error for an invalid pointer', async function () {
     try {
       await $RefParser.dereference(path.rel('specs/invalid-pointers/invalid.json'));
       helper.shouldNotGetCalled();
     } catch (err) {
       expect(err).to.be.an.instanceOf(InvalidPointerError);
-      expect(err.message).to.contain('Invalid $ref pointer "f". Pointers must begin with "#/"');
+      expect(err.message).to.contain('Invalid $ref pointer "./invalid.json#f". Pointers must begin with "#/"');
     }
   });
 

--- a/test/specs/invalid-pointers/invalid-pointers.spec.js
+++ b/test/specs/invalid-pointers/invalid-pointers.spec.js
@@ -10,7 +10,7 @@ const { expect } = chai;
 chai.use(chaiSubset);
 
 describe('Schema with invalid pointers', function () {
-  it.only('should throw an error for an invalid pointer', async function () {
+  it('should throw an error for an invalid pointer', async function () {
     try {
       await $RefParser.dereference(path.rel('specs/invalid-pointers/invalid.json'));
       helper.shouldNotGetCalled();


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes
Follow up from https://github.com/readmeio/json-schema-ref-parser/pull/102
- Was referencing the wrong key in one of the objects.
- Added a check for the `continueOnErrors` option

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
